### PR TITLE
fix: zip file is not closed after unzipping

### DIFF
--- a/src/zip_reader.cc
+++ b/src/zip_reader.cc
@@ -54,6 +54,11 @@ void UpdateFileTime(const std::string& file_path,
 
 namespace zip {
 
+ZipReader::~ZipReader() {
+  if (zip_file_)
+    unzClose(zip_file_);
+}
+  
 ZipReader::EntryInfo::EntryInfo(const std::string& file_name_in_zip,
                                 const unz_file_info& file_info)
     : file_path(file_name_in_zip), raw_file_info(file_info),

--- a/src/zip_reader.h
+++ b/src/zip_reader.h
@@ -14,7 +14,7 @@ namespace zip {
 class ZipReader {
  public:
   ZipReader() {}
-  ~ZipReader() {}
+  ~ZipReader();
 
   // This class represents information of an entry (file or directory) in
   // a zip file.


### PR DESCRIPTION
this issue cased zip file couldn't be deleted once it had been unzipped on Windows.

Though, it worked without problem with this issue unfixed on OS X, I think it just because the OS X 'ignore' this error somehow.
